### PR TITLE
Fixes on access to Magento Backend pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,18 @@ module "oci-arch-magento-mds" {
 ```
 
 ### Testing your Deployment
-After the deployment is finished, you can access and configure Magento by picking magento_home_URL from the output and pasting into web browser window.
+After the deployment is finished, you can access Magento home page by picking magento_home_URL from the output and pasting it into web browser window.
 
 ````
-magento_home_URL = http://193.122.198.20/
+magento_home_URL = "http://193.122.198.20/"
+`````
+
+If you wan to access Magento backend then you need to pickup magento_backend_URL from the output and paste it into web browser window. Then use magento_backend_username and magento_backend_password to authorize the access to Magento backend pages.
+
+````
+magento_backed_URL       = "http://193.122.198.20/index.php/magento_admin/"
+magento_backend_password = "BEstrO0ng_#11"
+magento_backend_username = "admin"
 `````
 
 ## Contributing

--- a/magento.tf
+++ b/magento.tf
@@ -1,7 +1,7 @@
 ## Copyright (c) 2022 Oracle and/or its affiliates.
 ## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
 
-module "magento" {
+module "oci-arch-magento" {
   source                    = "github.com/oracle-devrel/terraform-oci-arch-magento"
   tenancy_ocid              = var.tenancy_ocid
   vcn_id                    = oci_core_virtual_network.magento_mds_vcn.id
@@ -24,6 +24,7 @@ module "magento" {
   magento_password          = var.magento_password
   magento_admin_password    = var.magento_admin_password
   magento_admin_email       = var.magento_admin_email
+  magento_backend_frontname = var.magento_backend_frontname
   display_name              = var.magento_instance_name
   flex_shape_ocpus          = var.node_flex_shape_ocpus
   flex_shape_memory         = var.node_flex_shape_memory

--- a/orm/variables.tf
+++ b/orm/variables.tf
@@ -7,7 +7,7 @@
 
 variable "release" {
   description = "Reference Architecture Release (OCI Architecture Center)"
-  default     = "1.1"
+  default     = "1.2"
 }
 
 variable "ssh_public_key" {
@@ -144,6 +144,11 @@ variable "magento_schema" {
 variable "mds_instance_name" {
   description = "Name of the MDS instance"
   default     = "magentoMDS"
+}
+
+variable "magento_backend_frontname" {
+  description = "Magento Admin Backend Frontname"
+  default     = "magento_admin"
 }
 
 variable "mysql_is_highly_available" {

--- a/output.tf
+++ b/output.tf
@@ -2,24 +2,24 @@
 ## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
 
 output "magento_home_URL" {
-  value = "http://${module.magento.public_ip[0]}/"
+  value = "http://${module.oci-arch-magento.public_ip[0]}/"
 }
 
-output "generated_ssh_private_key" {
-  value     = module.magento.generated_ssh_private_key
-  sensitive = true
+output "magento_backend_URL" {
+  value = "http://${module.oci-arch-magento.public_ip[0]}/index.php/${var.magento_backend_frontname}/"
 }
 
-output "magento_name" {
-  value = var.magento_name
+output "magento_backend_username" {
+  value = "admin"
 }
 
-output "magento_password" {
+output "magento_backend_password" {
   value = var.magento_password
 }
 
-output "magento_database" {
-  value = var.magento_schema
+output "generated_ssh_private_key" {
+  value     = module.oci-arch-magento.generated_ssh_private_key
+  sensitive = true
 }
 
 output "mds_instance_ip" {

--- a/schema.yaml
+++ b/schema.yaml
@@ -91,6 +91,7 @@ variableGroups:
       - magento_instance_name
       - magento_name
       - magento_schema
+      - magento_backend_frontname
 
   - title: MDS Optional Configuration
     visible: 
@@ -435,6 +436,12 @@ variables:
     required: true
     title: MySQL Magento Schema
     description: MySQL Schema/Database for Magento
+
+  magento_backend_frontname:
+    type: string
+    required: false
+    title: Magento Backend Frontname
+    description: Magento Backend Frontname (Admin Console)
 
   use_shared_storage:
     type: boolean

--- a/tags.tf
+++ b/tags.tf
@@ -25,7 +25,7 @@ resource "oci_identity_tag" "ArchitectureCenterTag" {
 
   validator {
     validator_type = "ENUM"
-    values         = ["release", "1.1"]
+    values         = ["release", "1.2"]
   }
 
   provisioner "local-exec" {

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "private_key_path" {}
 
 variable "release" {
   description = "Reference Architecture Release (OCI Architecture Center)"
-  default     = "1.1"
+  default     = "1.2"
 }
 
 variable "ssh_public_key" {
@@ -144,6 +144,11 @@ variable "magento_schema" {
 variable "mds_instance_name" {
   description = "Name of the MDS instance"
   default     = "magentoMDS"
+}
+
+variable "magento_backend_frontname" {
+  description = "Magento Admin Backend Frontname"
+  default     = "magento_admin"
 }
 
 variable "mysql_is_highly_available" {


### PR DESCRIPTION
## What's changed
- `magento_backend_URL` added to output.tf.
- customized Magento's backend URL by `magento_backend_frontname` variable.
- refreshed README file (now includes how to access Magento backend).